### PR TITLE
Add a google group validation

### DIFF
--- a/Makefile.toptal
+++ b/Makefile.toptal
@@ -1,0 +1,44 @@
+APP_NAME = traefik-forward-auth
+
+APP_VERSION ?= $(shell git describe --tags --always)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+BRANCH ?= $(shell git symbolic-ref --short HEAD 2>/dev/null)
+TAGS = $(shell docker image inspect --format='{{ join .RepoTags " " }}' $(CONTAINER_NAME):$(APP_VERSION))
+GCE_PROJECT = toptal-hub
+CONTAINER_NAME = gcr.io/$(GCE_PROJECT)/$(APP_NAME)
+EXTRA_ARGS ?=
+
+with_commit:
+ifneq (${COMMIT},)
+	@echo -n $(eval EXTRA_ARGS += -t $(CONTAINER_NAME):$(COMMIT))
+endif
+
+with_latest:
+	@echo -n $(eval EXTRA_ARGS += -t $(CONTAINER_NAME):latest)
+
+clean:
+	@echo -n $(eval EXTRA_ARGS += --force-rm --no-cache --pull)
+
+debug:
+	@echo -n $(eval EXTRA_ARGS += --progress plain)
+
+version:
+	@echo $(APP_VERSION)
+
+image:
+	DOCKER_BUILDKIT=1 docker build $(EXTRA_ARGS) -t $(CONTAINER_NAME):$(APP_VERSION) --build-arg APP_VERSION=$(APP_VERSION) -f Dockerfile .
+
+push:
+	for tag in $(TAGS) ; do \
+	  docker push $$tag ; \
+	done
+
+bash:
+	docker run -it --entrypoint="" --rm $(CONTAINER_NAME):$(APP_VERSION) bash
+
+help:
+	docker run -it --rm $(CONTAINER_NAME):$(APP_VERSION) --help
+
+.PHONY: test
+test:
+	docker run --rm  -v "$$PWD":/usr/src/myapp -w /usr/src/myapp -v $$GOOGLE_APPLICATION_CREDENTIALS:/tmp/credentials.json:ro -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials.json golang:1.13 make test

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,14 @@ go 1.13
 require (
 	github.com/containous/traefik/v2 v2.1.2
 	github.com/coreos/go-oidc v2.1.0+incompatible
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/thomseddon/go-flags v1.4.1-0.20190507184247-a3629c504486
+	golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	google.golang.org/api v0.8.0
 	gopkg.in/square/go-jose.v2 v2.3.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 github.com/Azure/azure-sdk-for-go v32.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -166,6 +167,7 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -204,6 +206,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -397,6 +400,7 @@ go.etcd.io/bbolt v1.3.1-etcd.8/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XK
 go.etcd.io/etcd v3.3.13+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -478,6 +482,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20161028155119-f51c12702a4d/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -502,6 +507,7 @@ gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6d
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.8.0 h1:VGGbLNyPF7dvYHhcUGYBBGCRDDK0RRJAI6KCvo0CL+E=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
@@ -511,12 +517,14 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+google.golang.org/grpc v1.22.1 h1:/7cs52RnTJmD43s3uxzlq2U7nqVTd/37viQwMrMNlOM=
 google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/DataDog/dd-trace-go.v1 v1.16.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -97,6 +97,32 @@ func ValidateEmail(email, ruleName string) bool {
 	return false
 }
 
+// ValidateGoogleGroup checks if the given email address is a member of any google
+// group, as defined by the "group" config parameter.
+func ValidateGoogleGroup(directory *Directory, email, ruleName string) bool {
+	// Use global config by default
+	groups := config.GoogleGroups
+
+	if rule, ok := config.Rules[ruleName]; ok {
+		// Override with rule config if found
+		if len(rule.GoogleGroups) > 0 {
+			groups = rule.GoogleGroups
+		}
+	}
+
+	// Do we have any validation to perform?
+	if len(groups) == 0 {
+		return true
+	}
+
+	// GoogleGroup validation
+	if ValidateGoogleGroups(directory, email, groups) {
+		return true
+	}
+
+	return false
+}
+
 // ValidateWhitelist checks if the email is in whitelist
 func ValidateWhitelist(email string, whitelist CommaSeparatedList) bool {
 	for _, whitelist := range whitelist {
@@ -115,6 +141,16 @@ func ValidateDomains(email string, domains CommaSeparatedList) bool {
 	}
 	for _, domain := range domains {
 		if domain == parts[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateGoogleGroups checks if the email is a member of a google group
+func ValidateGoogleGroups(directory *Directory, email string, groups CommaSeparatedList) bool {
+	for _, group := range groups {
+		if directory.IsMember(email, group) {
 			return true
 		}
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -40,6 +40,12 @@ type Config struct {
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
 	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, can be set multiple times"`
 
+	GoogleGroups                 CommaSeparatedList `long:"google-group" env:"GOOGLE_GROUP" env-delim:"," description:"Only allow given Google groups, can be set multiple times"`
+	GoogleDomain                 string             `long:"google-domain" env:"GOOGLE_DOMAIN" description:"Google domain used for gcloud API"`
+	GoogleApplicationCredentials string             `long:"google-application-credentials" env:"GOOGLE_APPLICATION_CREDENTIALS" description:"Google service account JSON file used for gcloud API"`
+	GoogleActingAdminEmail       string             `long:"google-acting-admin-email" env:"GOOGLE_ACTING_ADMIN_EMAIL" description:"The gcloud admin account the service account delegates to for gcloud API"`
+	GoogleExpirySeconds          int64              `long:"google-expiry-seconds" env:"GOOGLE_EXPIRY_SECONDS" default:"600" description:"How long a users Google groups list is cached before refreshing from the API"`
+
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
 	Rules     map[string]*Rule   `long:"rule.<name>.<param>" description:"Rule definitions, param can be: \"action\", \"rule\" or \"provider\""`
 
@@ -218,6 +224,10 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 			list := CommaSeparatedList{}
 			list.UnmarshalFlag(val)
 			rule.Domains = list
+		case "google_groups":
+			list := CommaSeparatedList{}
+			list.UnmarshalFlag(val)
+			rule.GoogleGroups = list
 		default:
 			return args, fmt.Errorf("invalid route param: %v", option)
 		}
@@ -335,11 +345,12 @@ func (c *Config) setupProvider(name string) error {
 
 // Rule holds defined rules
 type Rule struct {
-	Action    string
-	Rule      string
-	Provider  string
-	Whitelist CommaSeparatedList
-	Domains   CommaSeparatedList
+	Action       string
+	Rule         string
+	Provider     string
+	Whitelist    CommaSeparatedList
+	Domains      CommaSeparatedList
+	GoogleGroups CommaSeparatedList
 }
 
 // NewRule creates a new rule object

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -37,6 +37,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.False(c.MatchWhitelistOrDomain)
 	assert.Equal("/_oauth", c.Path)
 	assert.Len(c.Whitelist, 0)
+	assert.Len(c.GoogleGroups, 0)
 
 	assert.Equal("select_account", c.Providers.Google.Prompt)
 }
@@ -204,6 +205,7 @@ func TestConfigParseEnvironment(t *testing.T) {
 	os.Setenv("COOKIE_DOMAIN", "test1.com,example.org")
 	os.Setenv("DOMAIN", "test2.com,example.org")
 	os.Setenv("WHITELIST", "test3.com,example.org")
+	os.Setenv("GOOGLE_GROUP", "group1,group2")
 
 	c, err := NewConfig([]string{})
 	assert.Nil(err)
@@ -216,12 +218,14 @@ func TestConfigParseEnvironment(t *testing.T) {
 	}, c.CookieDomains, "array variable should be read from environment COOKIE_DOMAIN")
 	assert.Equal(CommaSeparatedList{"test2.com", "example.org"}, c.Domains, "array variable should be read from environment DOMAIN")
 	assert.Equal(CommaSeparatedList{"test3.com", "example.org"}, c.Whitelist, "array variable should be read from environment WHITELIST")
+	assert.Equal(CommaSeparatedList{"group1", "group2"}, c.GoogleGroups, "array variable should be read from environment GOOGLE_GROUP")
 
 	os.Unsetenv("COOKIE_NAME")
 	os.Unsetenv("PROVIDERS_GOOGLE_CLIENT_ID")
 	os.Unsetenv("COOKIE_DOMAIN")
 	os.Unsetenv("DOMAIN")
 	os.Unsetenv("WHITELIST")
+	os.Unsetenv("GOOGLE_GROUP")
 }
 
 func TestConfigParseEnvironmentBackwardsCompatability(t *testing.T) {

--- a/internal/directory.go
+++ b/internal/directory.go
@@ -1,0 +1,93 @@
+package tfa
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/admin/directory/v1"
+	"io/ioutil"
+	"time"
+)
+
+type Directory struct {
+	cache                        map[string][]string
+	ttl                          map[string]int64
+	domain                       string
+	googleApplicationCredentials string
+	actingAdminEmail             string
+	expirySeconds                int64
+}
+
+func NewDirectory() *Directory {
+	cache := make(map[string][]string)
+	ttl := make(map[string]int64)
+	domain := config.GoogleDomain
+	googleApplicationCredentials := config.GoogleApplicationCredentials
+	actingAdminEmail := config.GoogleActingAdminEmail
+	expirySeconds := config.GoogleExpirySeconds
+	return &Directory{cache, ttl, domain, googleApplicationCredentials, actingAdminEmail, expirySeconds}
+}
+
+func (d *Directory) IsMember(email string, group string) bool {
+	for _, g := range d.groups(email) {
+		if g == group {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Directory) groups(email string) []string {
+	if ttl, ok := d.ttl[email]; !ok || time.Now().Unix() > ttl {
+		if list, err := d.getGroups(email); err == nil {
+			log.WithFields(logrus.Fields{"email": email}).Info("Fetched groups from API")
+			d.cache[email] = list
+			d.ttl[email] = time.Now().Unix() + d.expirySeconds
+		} else {
+			log.Error(err)
+			delete(d.cache, email)
+			delete(d.ttl, email)
+		}
+	}
+
+	if groups, ok := d.cache[email]; ok {
+		return groups
+	}
+	return []string{}
+}
+
+func (d *Directory) getGroups(email string) ([]string, error) {
+	srv, err := d.createService()
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := srv.Groups.List().Domain(d.domain).UserKey(email).MaxResults(200).Do()
+	if err != nil {
+		return nil, err
+	}
+	var list []string
+	for _, g := range groups.Groups {
+		list = append(list, g.Email)
+	}
+	return list, nil
+}
+
+func (d *Directory) createService() (*admin.Service, error) {
+	json, err := ioutil.ReadFile(d.googleApplicationCredentials)
+	if err != nil {
+		return nil, err
+	}
+	config, err := google.JWTConfigFromJSON(json, admin.AdminDirectoryGroupReadonlyScope)
+	if err != nil {
+		return nil, err
+	}
+	config.Subject = d.actingAdminEmail
+	ctx := context.Background()
+	client := config.Client(ctx)
+	srv, err := admin.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return srv, nil
+}

--- a/internal/directory_test.go
+++ b/internal/directory_test.go
@@ -1,0 +1,27 @@
+package tfa
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+/**
+ * Tests
+ */
+
+func TestDirectory(t *testing.T) {
+	assert := assert.New(t)
+	config = newDefaultConfig()
+	config.GoogleGroups = []string{"core@toptal.com"}
+	config.GoogleDomain = "toptal.com"
+	config.GoogleApplicationCredentials = "/tmp/credentials.json"
+	config.GoogleActingAdminEmail = "services-core@toptal.com"
+	config.GoogleExpirySeconds = 10
+	directory := NewDirectory()
+	assert.Empty(directory.cache, "cache should be empty")
+	assert.Empty(directory.ttl, "ttl should be empty")
+	assert.True(directory.IsMember("jonathan.doveston@toptal.com", "core@toptal.com"), "should be a member")
+	assert.False(directory.IsMember("jonathan.doveston@toptal.com", "billing-team@toptal.com"), "should not be a member")
+	assert.NotEmpty(directory.cache, "cache should not be empty")
+	assert.NotEmpty(directory.ttl, "ttl should not be empty")
+}


### PR DESCRIPTION
In the same way that the email domain and the email whitelist is checked, the
email is now checked for google group membership. To check an email is a member
of a google group requires access to the gcloud API for the whole google domain.
The official Google Gcloud API client library is used and requires extra
configuration:

- GoogleDomain is the domain managed by GCloud
- GoogleGroup is a comma delimited list of the required group emails
- GoogleApplicationCredentials is path to service account JSON credentials file
- GoogleActingAdminEmail is the email an admin account with domain access
- GoogleExpirySeconds is the number of seconds the API response is cached

The service account requires domain-wide delegation of authority as discussed
here https://developers.google.com/admin-sdk/directory/v1/guides/delegation.
It also requires the oauth scope
https://www.googleapis.com/auth/admin.directory.group.readonly to be able to
read the groups of a member email. This service account has to impersonate an
admin account to access the admin APIs.

The default google groups required for authorization is specified in the
GoogleGroup variable, but can also be specified in a Rule like:

--rule.1.action=allow
--rule.1.rule=Host(`example.com`)
--rule.1.google_groups=team@example.com